### PR TITLE
Added missing "do" command

### DIFF
--- a/addons/source-python/plugins/es_emulator/eventscripts/wcs/tools/manifest/soul_rapist/es_soul_rapist.txt
+++ b/addons/source-python/plugins/es_emulator/eventscripts/wcs/tools/manifest/soul_rapist/es_soul_rapist.txt
@@ -99,7 +99,7 @@ block damage_based_on_hp
 				}
 				if (server_var(wcs_tmp2) >= 81) do
 				{
-					if (server_var(wcs_tmp2) <= 95)
+					if (server_var(wcs_tmp2) <= 95) do
 					{
 						es_xrand wcs_dmg 25 35
 					}


### PR DESCRIPTION
do command was missing, this fixes the " [wcs/tools/manifest/soul_rapist/damage_based_on_hp 1011] if: Syntax: if (<value> <operator> <value>) <do/then> [[commandstring]] " exception.

Thanks to @thapwned for fixing the issue.